### PR TITLE
add bash syntax highlighting

### DIFF
--- a/components/markdown/components/code-block.js
+++ b/components/markdown/components/code-block.js
@@ -6,6 +6,7 @@ hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'));
 hljs.registerLanguage('csharp', require('highlight.js/lib/languages/csharp'));
 hljs.registerLanguage('javascript', require('highlight.js/lib/languages/javascript'));
 hljs.registerLanguage('typescript', require('highlight.js/lib/languages/typescript'));
+hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'));
 
 class CodeBlock extends React.PureComponent {
   constructor(properties) {


### PR DESCRIPTION
#### Changes

- Add syntax highlighting for `hljs` which is used to parse markdown code blocks.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
