### PR TITLE
Update CONTRIBUTING.md to reflect the need of "yarn build"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ Steps to be performed to submit a pull request:
 1. Fork the repository and create your branch from `main`.
 2. Run `yarn` in the repository root.
 3. If you've fixed a bug or added code that should be tested, add tests!
-4. Fill out the description, link any related issues and submit your pull request.
+4. Run `yarn build` and make sure no errors are generated in the console before creating the PR.
+5. Fill out the description, link any related issues and submit your pull request.
 
 #### Pull Request Prerequisites
 


### PR DESCRIPTION
#### Changes

- Added a line in the contributing guidelines to make sure contributors run `yarn build` before submitting the PR because vercel will fail and give no indications as of why (just a 404 page) if there are errors in the build.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (not needed)
- [x] Tests (not needed)
