### PR TITLE
Clarify documentation about androidKeystoreName

### DIFF
--- a/docs/github/builder.md
+++ b/docs/github/builder.md
@@ -217,7 +217,10 @@ _**default:** `false`_
 
 #### androidKeystoreName
 
-Configure the android `keystoreName`.
+Configure the android `keystoreName`. Must be provided if configuring the below keystore options. 
+
+For this to take effect, you must not have your project set to use a custom keystore. If you have it set to use a
+custom keystore, all keystore settings will be ignored, and the build will likely fail with an error in signing.
 
 _**required:** `false`_
 _**default:** `""`_


### PR DESCRIPTION
#### Changes

- Clarify keystore name is required to generate keystore
- Point out custom keystore must not be checked in the Unity player settings

I ran into these two points when trying to build an android app with this action, otherwise the signing works fine :)

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)
